### PR TITLE
gameListにファイナルファンタジーを追加

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,19 +5,7 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="81183098-57b8-42cc-af0e-1213e776a7aa" name="変更" comment="">
-      <change afterPath="$PROJECT_DIR$/.gitignore" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/.idea/gradle.xml" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/.idea/misc.xml" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/.idea/saveactions_settings.xml" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/.idea/vcs.xml" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/build.gradle" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/gradle/wrapper/gradle-wrapper.jar" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/gradle/wrapper/gradle-wrapper.properties" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/gradlew" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/gradlew.bat" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/settings.gradle" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/example/Main.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 public class Main {
     public static void main(String[] args) {
-        List<String> gamesList = List.of("ボンバーマン","星のカービィ","スマッシュブラザーズ","ポケモン","ゼルダの伝説");
+        List<String> gamesList = List.of("ボンバーマン","星のカービィ","スマッシュブラザーズ","ポケモン","ゼルダの伝説","ファイナルファンタジー","ロックマン");
 
         gamesList.forEach(System.out::println);
     }


### PR DESCRIPTION
# 概要
ゲームの一覧にファイナルファンタジーを追加して表示できるようにしました。

# 動作確認
<img width="169" alt="スクリーンショット 2023-09-13 17 46 03" src="https://github.com/otyacazyu/github-homewoke5/assets/143002834/94a623d4-4781-4696-bcf2-3c03a329bc71">
